### PR TITLE
Drop use of CSRF token, make compatible with Django 4.1 update

### DIFF
--- a/rest_framework_microservice/views.py
+++ b/rest_framework_microservice/views.py
@@ -1,7 +1,6 @@
 from datetime import datetime
 from django.conf import settings
 from .settings import rest_microservice_settings
-from django.middleware import csrf
 from rest_framework import status
 from rest_framework.response import Response
 from rest_framework.views import APIView
@@ -20,18 +19,7 @@ class RefreshTokenUsingCookieMixin:
 
     def set_cookie_header_in_response(self, response, refresh_token, refresh_expiry):
         expires = datetime.fromtimestamp(refresh_expiry)
-        # set matching pair of csrf token in cookie and in response body
-        csrf_token = self.get_csrf_token()
-        response.data.update({"CSRF_token": csrf_token})
-        response.set_signed_cookie(key='CSRF_token',
-                                   value=csrf_token,
-                                   salt=rest_microservice_settings.COOKIE_SALT,
-                                   expires=expires,
-                                   httponly=True,
-                                   samesite='strict',
-                                   secure=not settings.DEBUG,
-                                   path=rest_microservice_settings.REFRESH_COOKIE_PATH)
-        # set refresh token
+
         response.set_signed_cookie(key=rest_microservice_settings.REFRESH_COOKIE_NAME,
                                    value=refresh_token,
                                    salt=rest_microservice_settings.COOKIE_SALT,
@@ -43,17 +31,9 @@ class RefreshTokenUsingCookieMixin:
     @staticmethod
     def get_token_from_cookie(request):
         try:
-            csrf_from_cookie = request.get_signed_cookie('CSRF_token', salt=rest_microservice_settings.COOKIE_SALT)
-            csrf_from_body = request.data.get('CSRF_token')
             token = request.get_signed_cookie(rest_microservice_settings.REFRESH_COOKIE_NAME,
                                               salt=rest_microservice_settings.COOKIE_SALT)
-        except KeyError:
-            raise InvalidToken()
-
-        if csrf_from_cookie is None or csrf_from_body is None:
-            raise InvalidToken()
-
-        if csrf._does_token_match(csrf_from_cookie, csrf_from_body) is False:
+        except KeyError as e:
             raise InvalidToken()
 
         return token
@@ -61,15 +41,9 @@ class RefreshTokenUsingCookieMixin:
     @staticmethod
     def get_delete_cookie_response(status_code=status.HTTP_401_UNAUTHORIZED):
         response = Response(status=status_code)
-        response.delete_cookie('CSRF_token', path=rest_microservice_settings.REFRESH_COOKIE_PATH)
         response.delete_cookie(key=rest_microservice_settings.REFRESH_COOKIE_NAME,
                                path=rest_microservice_settings.REFRESH_COOKIE_PATH)
         return response
-
-    @staticmethod
-    def get_csrf_token():
-        """Returns a csrf token."""
-        return csrf._mask_cipher_secret(csrf._get_new_csrf_string())
 
 
 class TokenLogIn(TokenObtainPairView, RefreshTokenUsingCookieMixin):

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = django-rest-microservice
-version = 1.1
+version = 1.2
 description = Facilitating microservice architecture in Django REST framework
 long_description = file: README.md
 url = https://github.com/oscarychen/django-rest-microservice


### PR DESCRIPTION
Remove setting CSRF token from log in api, remove validation of CSRF tokens from refresh and logoff APIs.